### PR TITLE
Accepting both lvalue and rvalue references in shift operator

### DIFF
--- a/include/StreamManager.h
+++ b/include/StreamManager.h
@@ -52,7 +52,7 @@ namespace MsgPack {
         /*! Tries to serialize one MsgPack::Element into the streamBuffer
          @param element std::unique_ptr containing the element
          */
-        Serializer& operator<<(std::unique_ptr<Element>& element) {
+        Serializer& operator<<(std::unique_ptr<Element>&& element) {
             Serializer::serialize(element);
             return *this;
         }


### PR DESCRIPTION
Following code failed to compile before this change:

```c++
std::streambuf* buffer = getBufferFromSomewhere();
MsgPack::Serializer serializer(buffer);
serializer << MsgPack__Factory(MapHeader(7));
```

Because `MsgPack__Factory(MapHeader(7))` expanded into an rvalue.