### PR TITLE
Fix Socket::sync if a client is disconnected

### DIFF
--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -138,6 +138,8 @@ int Socket::sync() {
         return EOF;
     if(pptr() == pbase()) // Allready in sync
         return 0;
+    if(this->status == BUSY) //Not able to write data
+		return EOF;
     try {
         std::streamsize rest = pptr()-pbase(),
                         sentBytes = send(pbase(), rest);


### PR DESCRIPTION
If a client is disconnected during the transfer progress, socket status will be BUSY.  Socket::sync will not be able to write any data and should return EOF instead.